### PR TITLE
Fix typo: cloud-inint -> cloud-init in config.toml.in

### DIFF
--- a/config.toml.in
+++ b/config.toml.in
@@ -36,7 +36,7 @@ packages = [ "rates" ]
 # Ubuntu features to remove/disable
 [ubuntu.remove]
 apport = false              # Remove crash reporting
-cloud-inint = false         # Remove cloud-init
+cloud-init = false          # Remove cloud-init
 kdump-tools = false         # Remove kernel crash dump tools
 multipath-tools = false     # Remove tools for disk multipath device maps
 pollinate = true            # Remove entropy seeding


### PR DESCRIPTION
## Summary
- Fixes typo in `config.toml.in`: `cloud-inint` → `cloud-init`

## Problem
The `[ubuntu.remove]` section had a misspelled key `cloud-inint`. Since `just/ubuntu.just` correctly looks for `ubuntu.remove.cloud-init`, this option was silently ignored - users couldn't actually remove cloud-init even when setting it to `true`.

## Test plan
- [ ] Verify `just switch` correctly removes cloud-init when `cloud-init = true` is set

🤖 Generated with [Claude Code](https://claude.ai/code)